### PR TITLE
Remove `srcset` attribute in case of an error

### DIFF
--- a/lazyload-image.js
+++ b/lazyload-image.js
@@ -55,6 +55,7 @@
     };
 
     this.onError = function (e) {
+      that.removeAttribute('srcset');
       that.src = FALLBACK_IMAGE;
       window.removeEventListener('scroll', that.onScroll);
     };


### PR DESCRIPTION
Setting element.src in case of an error results in a new evaluation of srcset. If a matching srcset results in an error, this results in an infinite loop.
I think in case of an error we want to ignore `srcset` and simply show `FALLBACK_IMAGE` for any device / resolution.
